### PR TITLE
makefiles: fix typo in target DESTDIR

### DIFF
--- a/bindtextdomain/Makefile
+++ b/bindtextdomain/Makefile
@@ -12,7 +12,7 @@ libpreload-$(TARGET).so: preload-$(TARGET).c
 		-o $@ -ldl
 
 install: libpreload-$(TARGET).so
-	install -m644 -D libpreload-$(TARGET).so ${DESTIR}/libpreload-$(TARGET).so
+	install -m644 -D libpreload-$(TARGET).so ${DESTDIR}/libpreload-$(TARGET).so
 
 clean:
 	rm -f \

--- a/chromium-content-api/Makefile
+++ b/chromium-content-api/Makefile
@@ -12,7 +12,7 @@ libpreload-$(TARGET).so: preload-$(TARGET).c
 		-o $@ -ldl
 
 install: libpreload-$(TARGET).so
-	install -m644 -D libpreload-$(TARGET).so ${DESTIR}/libpreload-$(TARGET).so
+	install -m644 -D libpreload-$(TARGET).so ${DESTDIR}/libpreload-$(TARGET).so
 
 clean:
 	rm -f \

--- a/semaphores/Makefile
+++ b/semaphores/Makefile
@@ -1,6 +1,6 @@
 CFLAGS += -g -O0 -Wall -Wstrict-prototypes
 
-.PHONY: env-check clean
+.PHONY: clean
 
 all: libpreload-semaphores.so
 
@@ -11,7 +11,7 @@ libpreload-semaphores.so: preload-semaphores.c
 		-o $@ -ldl
 
 install: libpreload-semaphores.so
-	install -D libpreload-semaphores.so ${DESTIR}/libpreload-semaphores.so
+	install -D libpreload-semaphores.so ${DESTDIR}/libpreload-semaphores.so
 
 clean:
 	rm -f \


### PR DESCRIPTION
Also remove invalid .PHONY target in one of the makefiles.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>