### PR TITLE
makefile and chromium-content-api fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,17 @@
-TARGETS := chromium-content-api semaphores bindtextdomain
-
+.PHONY: all
 all:
-	$(foreach dir, $(TARGETS), $(MAKE) -C $(dir);)
+	make -C chromium-content-api $@
+	make -C semaphores $@
+	make -C bindtextdomain $@
 
+.PHONY: install
 install:
-	$(foreach dir, $(TARGETS), $(MAKE) install -C $(dir);)
+	make -C chromium-content-api $@
+	make -C semaphores $@
+	make -C bindtextdomain $@
 
+.PHONY: clean
 clean:
-	$(foreach dir, $(TARGETS), $(MAKE) clean -C $(dir);)
+	make -C chromium-content-api $@
+	make -C semaphores $@
+	make -C bindtextdomain $@


### PR DESCRIPTION
Makefile: add PHONY statements and drop foreach to expose errors
chromium-content-api: fix overflow, missing free, just warn on truncate and clarify debug prints